### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+- - -
+
+**_This project is not actively maintained. Consider using [react-quickstart](https://github.com/andreypopp/react-quickstart) instead._**
+
+- - -
+
 # react-browserify-template
 
 ## Getting started:


### PR DESCRIPTION
People are finding this repo by searching Google for "react browserify" – let's point them to react-quickstart?
